### PR TITLE
hotfix (avdrpoc 17): disable collision detection

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,31 @@
+set dotenv-load
+
+[private]
+default:
+    @just --list --unsorted
+
+# Copy repo content to remote host with 'rsync' and watch for changes
+sync hostname="${ROBOT_NAMESPACE}" password="husarion": _install-rsync _run-as-user
+    #!/bin/bash
+    mkdir -m 775 -p maps
+    sshpass -p "{{password}}" rsync -vRr --exclude='.git/' --exclude='maps/' --delete ./ husarion@{{hostname}}:/home/husarion/avdr_ws/src/${PWD##*/}
+    while inotifywait -r -e modify,create,delete,move ./ --exclude='.git/' --exclude='maps/' ; do
+        sshpass -p "{{password}}" rsync -vRr --exclude='.git/' --exclude='maps/' --delete ./ husarion@{{hostname}}:/home/husarion/avdr_ws/src/${PWD##*/}
+    done
+
+_run-as-user:
+    #!/bin/bash
+    if [ "$EUID" -eq 0 ]; then
+        echo -e "\e[1;33mPlease re-run as non-root user\e[0m"
+        exit 1
+    fi
+
+_install-rsync:
+    #!/bin/bash
+    if ! command -v rsync &> /dev/null || ! command -v sshpass &> /dev/null || ! command -v inotifywait &> /dev/null; then
+        if [ "$EUID" -ne 0 ]; then
+            echo -e "\e[1;33mPlease run as root to install dependencies\e[0m"
+            exit 1
+        fi
+        apt install -y rsync sshpass inotify-tools
+    fi

--- a/open_manipulator_x_moveit/config/joint_limits.yaml
+++ b/open_manipulator_x_moveit/config/joint_limits.yaml
@@ -26,6 +26,9 @@ joint_limits:
     max_velocity: 4.796164779
     has_acceleration_limits: true
     max_acceleration: 18.7253757
+    has_position_limits: true
+    min_position: -3.14159
+    max_position: 3.14159
   joint2:
     has_velocity_limits: true
     max_velocity: 4.796164779

--- a/open_manipulator_x_moveit/config/rosbot_xl.srdf
+++ b/open_manipulator_x_moveit/config/rosbot_xl.srdf
@@ -114,4 +114,46 @@
     <disable_collisions link1="rl_wheel_link" link2="rr_wheel_link" reason="Never"/>
     <disable_collisions link1="rl_wheel_link" link2="slamtec_rplidar_link" reason="Never"/>
     <disable_collisions link1="rr_wheel_link" link2="slamtec_rplidar_link" reason="Never"/>
+    <disable_collisions link1="antenna_link" link2="gripper_left_link" reason="Never"/>
+    <disable_collisions link1="antenna_link" link2="gripper_right_link" reason="Never"/>
+    <disable_collisions link1="antenna_link" link2="link4" reason="Never"/>
+    <disable_collisions link1="antenna_link" link2="link5" reason="Never"/>
+    <disable_collisions link1="antenna_connector_link" link2="gripper_left_link" reason="Never"/>
+    <disable_collisions link1="antenna_connector_link" link2="gripper_right_link" reason="Never"/>
+    <disable_collisions link1="antenna_connector_link" link2="link4" reason="Never"/>
+    <disable_collisions link1="antenna_connector_link" link2="link5" reason="Never"/>
+    <disable_collisions link1="body_link" link2="gripper_left_link" reason="Never"/>
+    <disable_collisions link1="body_link" link2="gripper_right_link" reason="Never"/>
+    <disable_collisions link1="body_link" link2="link4" reason="Never"/>
+    <disable_collisions link1="body_link" link2="link5" reason="Never"/>
+    <disable_collisions link1="fl_wheel_link" link2="gripper_left_link" reason="Never"/>
+    <disable_collisions link1="fl_wheel_link" link2="gripper_right_link" reason="Never"/>
+    <disable_collisions link1="fl_wheel_link" link2="link5" reason="Never"/>
+    <disable_collisions link1="fr_wheel_link" link2="gripper_left_link" reason="Never"/>
+    <disable_collisions link1="fr_wheel_link" link2="gripper_right_link" reason="Never"/>
+    <disable_collisions link1="fr_wheel_link" link2="link5" reason="Never"/>
+    <disable_collisions link1="gripper_left_link" link2="link1" reason="Never"/>
+    <disable_collisions link1="gripper_left_link" link2="link2" reason="Never"/>
+    <disable_collisions link1="gripper_left_link" link2="link3" reason="Never"/>
+    <disable_collisions link1="gripper_right_link" link2="link1" reason="Never"/>
+    <disable_collisions link1="gripper_right_link" link2="link2" reason="Never"/>
+    <disable_collisions link1="gripper_right_link" link2="link3" reason="Never"/>
+    <disable_collisions link1="link1" link2="link4" reason="Never"/>
+    <disable_collisions link1="link1" link2="link5" reason="Never"/>
+    <disable_collisions link1="link2" link2="link4" reason="Never"/>
+    <disable_collisions link1="link2" link2="link5" reason="Never"/>
+    <disable_collisions link1="link3" link2="link5" reason="Never"/>
+    <disable_collisions link1="gripper_left_link" link2="rplidar_link" reason="Never"/>
+    <disable_collisions link1="gripper_right_link" link2="rplidar_link" reason="Never"/>
+    <disable_collisions link1="link1" link2="rplidar_link" reason="Never"/>
+    <disable_collisions link1="link2" link2="rplidar_link" reason="Never"/>
+    <disable_collisions link1="link3" link2="rplidar_link" reason="Never"/>
+    <disable_collisions link1="link4" link2="rplidar_link" reason="Never"/>
+    <disable_collisions link1="link5" link2="rplidar_link" reason="Never"/>
+    <disable_collisions link1="link4" link2="rl_wheel_link" reason="Never"/>
+    <disable_collisions link1="link4" link2="rr_wheel_link" reason="Never"/>
+    <disable_collisions link1="link4" link2="slamtec_rplidar_link" reason="Never"/>
+    <disable_collisions link1="link5" link2="rl_wheel_link" reason="Never"/>
+    <disable_collisions link1="link5" link2="rr_wheel_link" reason="Never"/>
+    <disable_collisions link1="link5" link2="slamtec_rplidar_link" reason="Never"/>
 </robot>

--- a/open_manipulator_x_moveit/config/rosbot_xl.srdf
+++ b/open_manipulator_x_moveit/config/rosbot_xl.srdf
@@ -114,6 +114,9 @@
     <disable_collisions link1="rl_wheel_link" link2="rr_wheel_link" reason="Never"/>
     <disable_collisions link1="rl_wheel_link" link2="slamtec_rplidar_link" reason="Never"/>
     <disable_collisions link1="rr_wheel_link" link2="slamtec_rplidar_link" reason="Never"/>
+
+    <!--HOTFIX: Collision pairs below are disabled to prevent need to orient arm to the rear to
+    operate and stop collision detection warnings. -->
     <disable_collisions link1="antenna_link" link2="gripper_left_link" reason="Never"/>
     <disable_collisions link1="antenna_link" link2="gripper_right_link" reason="Never"/>
     <disable_collisions link1="antenna_link" link2="link4" reason="Never"/>


### PR DESCRIPTION
# Description
This PR disables collision detection on various links, this prevents the need to manually moving arm to the rear in order to be able to operate the arm.

Real fix is to create a proper urdf model of the robot with the custom mounts.